### PR TITLE
Created SpecUtil to handle common api request config and common assertions.

### DIFF
--- a/src/test/java/com/api/tests/CountAPITest.java
+++ b/src/test/java/com/api/tests/CountAPITest.java
@@ -6,9 +6,9 @@ import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.*;
 import org.testng.annotations.Test;
 
-import com.api.constants.Role;
-import static com.api.utils.AuthTokenProvider.*;
-import static com.api.utils.ConfigManager.*;
+import static com.api.constants.Role.*;
+import com.api.utils.SpecUtil;
+
 
 import io.restassured.module.jsv.JsonSchemaValidator;
 
@@ -18,21 +18,13 @@ public class CountAPITest {
 	public void verifyCountAPIResponse() {
 			
 		given()
-			.baseUri(getProperty("BASE_URI"))
-		.and()
-			.header("Authorization", getToken(Role.FD))
-			.log().uri()
-			.log().method()
-			.log().headers()
+			.spec(SpecUtil.requestSpecWithAuth(FD))
 			.when()
 			.get("/dashboard/count")
 			.then()
-			.log().all()
-			.statusCode(200)
+			.spec(SpecUtil.responsSpec_OK())
 			.body("message", equalTo("Success"))
-			.time(lessThan(5000L))   // Time should be less than 500ms 
 			.body("data", notNullValue())
-			
 			.body("data.size()", equalTo(3))  
 			.body("data.count", everyItem(greaterThanOrEqualTo(0)))
 			.body("data.label", everyItem(not(blankOrNullString())))
@@ -44,16 +36,11 @@ public class CountAPITest {
 	public void countAPI_MisiingAuthToken() {
 		
 		given()
-			.baseUri(getProperty("BASE_URI"))
-			.and()
-			.log().uri()
-			.log().method()
-			.log().headers()
+			.spec(SpecUtil.requestSpec())
 			.when()
 			.get("/dashboard/count")
 			.then()
-			.log().all()
-			.statusCode(401);
+			.spec(SpecUtil.responsSpec_TEXT(401));
 	}
 	
 	

--- a/src/test/java/com/api/tests/LoginAPITest.java
+++ b/src/test/java/com/api/tests/LoginAPITest.java
@@ -2,7 +2,6 @@ package com.api.tests;
 
 import static io.restassured.RestAssured.*;
 
-import static io.restassured.http.ContentType.*;
 
 import static org.hamcrest.Matchers.*;
 
@@ -11,7 +10,8 @@ import java.io.IOException;
 import org.testng.annotations.Test;
 
 import com.api.pojo.UserCredentials;
-import static com.api.utils.ConfigManager.*;
+import com.api.utils.SpecUtil;
+
 
 import io.restassured.module.jsv.JsonSchemaValidator;
 
@@ -23,24 +23,11 @@ public class LoginAPITest {
 	
 	UserCredentials usercredentials = new UserCredentials("iamfd", "password");	
 		given()
-			.baseUri(getProperty("BASE_URI"))
-		.and()
-			.contentType(JSON)
-		.and()
-			.accept(JSON)
-		.and()
-			.body(usercredentials)
-			.log().uri()
-			.log().method()
-			.log().headers()
-			.log().body()
+			.spec(SpecUtil.requestSpec(usercredentials))
 		.when()
 			.post("login")
 		.then()
-			.log().all()
-			.statusCode(200)
-			.time(lessThan(10000L))
-			.and()
+			.spec(SpecUtil.responsSpec_OK())
 			.body("message", equalTo("Success"))
 			.and()
 			.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response-schema/LoginSchema.json"));

--- a/src/test/java/com/api/tests/MasterAPITest.java
+++ b/src/test/java/com/api/tests/MasterAPITest.java
@@ -3,11 +3,10 @@ package com.api.tests;
 import static org.hamcrest.Matchers.*;
 import org.testng.annotations.Test;
 
-import com.api.constants.Role;
-import com.api.utils.AuthTokenProvider;
-import com.api.utils.ConfigManager;
+import static com.api.constants.Role.*;
+import com.api.utils.SpecUtil;
 
-import io.restassured.http.ContentType.*;
+
 import io.restassured.module.jsv.JsonSchemaValidator;
 
 import static io.restassured.RestAssured.*;
@@ -18,18 +17,11 @@ public class MasterAPITest {
 	public void verifyMasterAPIResponse() {
 		
 		given()
-			.baseUri(ConfigManager.getProperty("BASE_URI"))
-			.and()
-			.header("Authorization" , AuthTokenProvider.getToken(Role.FD))
-			.and()
-			.contentType("")
-			.log().all()
+			.spec(SpecUtil.requestSpecWithAuth(FD))
 			.when()
 			.post("master")
 			.then()
-			.log().all()
-			.statusCode(200)
-			.time(lessThan(2000L)) // time should be less than 500ms
+			.spec(SpecUtil.responsSpec_OK())
 			.body("message", equalTo("Success"))
 			.body("data", notNullValue())
 			.body("data", hasKey("mst_oem"))
@@ -47,17 +39,11 @@ public class MasterAPITest {
 	public void invalidTokenMasterAPI() {
 		
 		given()
-		.baseUri(ConfigManager.getProperty("BASE_URI"))
-		.and()
-		.header("Authorization" ," ")
-		.and()
-		.contentType("")
-		.log().all()
+		.spec(SpecUtil.requestSpec())
 		.when()
 		.post("master")
 		.then()
-		.log().all()
-		.statusCode(401);
+		.spec(SpecUtil.responsSpec_TEXT(401));
 	}
 
 }

--- a/src/test/java/com/api/tests/UserDetailsAPITest.java
+++ b/src/test/java/com/api/tests/UserDetailsAPITest.java
@@ -1,18 +1,15 @@
 package com.api.tests;
 
-import static org.hamcrest.Matchers. *;
 
 import java.io.IOException;
 
 import org.testng.annotations.Test;
 
-import static com.api.utils.AuthTokenProvider.*;
+
 
 import static com.api.constants.Role.*;
-import com.api.utils.ConfigManager;
 
-import io.restassured.http.ContentType;
-import io.restassured.http.Header;
+import com.api.utils.SpecUtil;
 import io.restassured.module.jsv.JsonSchemaValidator;
 
 import static io.restassured.RestAssured.*;
@@ -21,24 +18,13 @@ public class UserDetailsAPITest {
 	
 	@Test
 	public void userDetailsAPIRequest() throws IOException{
-		Header header = new Header("Authorization" , getToken(SUP));
 		
 		given()
-			.baseUri(ConfigManager.getProperty("BASE_URI"))
-		.and()
-			.header(header)
-		.and()
-			.accept(ContentType.JSON)
-			.log().uri()
-			.log().headers()
-			.log().method()
-			.log().body()
+			.spec(SpecUtil.requestSpecWithAuth(FD))
 		.when()
 			.get("userdetails")
 		.then()
-			.log().all()
-			.statusCode(200)
-			.time(lessThan(10000L))
+			.spec(SpecUtil.responsSpec_OK())
 		.and()
 			.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response-schema/UserDetailsResponseSchema.json"));
 			

--- a/src/test/java/com/api/utils/SpecUtil.java
+++ b/src/test/java/com/api/utils/SpecUtil.java
@@ -1,0 +1,110 @@
+package com.api.utils;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+
+import static com.api.utils.ConfigManager.*;
+
+import org.hamcrest.Matchers;
+
+import com.api.constants.Role;
+import com.api.pojo.UserCredentials;
+
+public class SpecUtil {
+	
+	public static RequestSpecification requestSpec() {
+		//To take care of common request sections (methods)
+		
+		RequestSpecification requestSpecification = new RequestSpecBuilder()
+		.setBaseUri(getProperty("BASE_URI"))
+		.setContentType(ContentType.JSON)
+		.setAccept(ContentType.JSON)
+		.log(LogDetail.URI)
+		.log(LogDetail.METHOD)
+		.log(LogDetail.HEADERS)
+		.log(LogDetail.BODY)
+		.build();
+		
+		return requestSpecification;
+		
+		
+	}
+	
+	public static RequestSpecification requestSpec(Object payload) {
+		//To take care of common request sections (methods)
+		
+		RequestSpecification requestSpecification = new RequestSpecBuilder()
+		.setBaseUri(getProperty("BASE_URI"))
+		.setContentType(ContentType.JSON)
+		.setAccept(ContentType.JSON)
+		.setBody(payload)
+		.log(LogDetail.URI)
+		.log(LogDetail.METHOD)
+		.log(LogDetail.HEADERS)
+		.log(LogDetail.BODY)
+		.build();
+		
+		return requestSpecification;
+		
+		
+	}
+	
+	public static ResponseSpecification responsSpec_OK() {
+		
+		ResponseSpecification responseSpecification =new ResponseSpecBuilder()
+		.expectContentType(ContentType.JSON)
+		.expectStatusCode(200)
+		.expectResponseTime(Matchers.lessThan(2000L))
+		.log(LogDetail.ALL)
+		.build();
+		
+		return responseSpecification;
+	}
+	
+	public static RequestSpecification requestSpecWithAuth(Role role) {
+		//To take care of common request sections (methods)
+		
+		RequestSpecification requestSpecification = new RequestSpecBuilder()
+		.setBaseUri(getProperty("BASE_URI"))
+		.setContentType(ContentType.JSON)
+		.setAccept(ContentType.JSON)
+		.addHeader("Authorization", AuthTokenProvider.getToken(role))
+		.log(LogDetail.URI)
+		.log(LogDetail.METHOD)
+		.log(LogDetail.HEADERS)
+		.log(LogDetail.BODY)
+		.build();
+		
+		return requestSpecification;
+		
+		
+	}
+	
+public static ResponseSpecification responsSpec_TEXT(int statusCode) {
+		
+		ResponseSpecification responseSpecification =new ResponseSpecBuilder()
+		.expectStatusCode(statusCode)
+		.expectResponseTime(Matchers.lessThan(2000L))
+		.log(LogDetail.ALL)
+		.build();
+		
+		return responseSpecification;
+	}
+	
+public static ResponseSpecification responsSpec_JSON(int statusCode) {
+		
+		ResponseSpecification responseSpecification =new ResponseSpecBuilder()
+		.expectContentType(ContentType.JSON)
+		.expectStatusCode(statusCode)
+		.expectResponseTime(Matchers.lessThan(2000L))
+		.log(LogDetail.ALL)
+		.build();
+		
+		return responseSpecification;
+	}
+
+}


### PR DESCRIPTION
SpecUtil consists of the common RequestSpecBuilder and ResponseSpecBuilder. These utility methods have reduced the boilerplate code in our api tests, and also reduced the number of lines. Making the test code smaller and maintainable